### PR TITLE
chore: API 키 환경변수 설정 추가

### DIFF
--- a/src/main/java/com/codeit/findex/FindexApplication.java
+++ b/src/main/java/com/codeit/findex/FindexApplication.java
@@ -7,6 +7,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class FindexApplication {
 
     public static void main(String[] args) {
+        // API-KEY 출력 테스트
+        System.out.println("API KEY = " + System.getenv("FINDEX_API_KEY"));
         SpringApplication.run(FindexApplication.class, args);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,7 @@ logging:
   pattern:
     console: "%d{HH:mm:ss} %-5level %logger{36} - %msg%n"
 
-
+# API-KEY
+findex:
+  api:
+    key: ${FINDEX_API_KEY}


### PR DESCRIPTION
# API 키 환경변수 설정 추가
환경변수 설정 & 테스트 코드 추가

## 변경 사항
- application.yaml에 findex.api.key=${FINDEX_API_KEY} 설정 추가
- 환경 변수 기반으로 API 키 관리 가능하도록 변경
- 간단한 테스트 코드로 정상 주입 여부 확인

## 변경 이유
- 기존에는 API 키를 코드에 직접 넣을 위험이 있었음
- 환경 변수를 통해 보안 강화 및 배포 환경별 유연한 설정 가능

## 환경변수 설정법 (IntelliJ 버전)
1. Run(실행) → Edit Configurations(구성 편집) 메뉴 클릭
2. Environment variables 항목에 아래 입력 (안보일시 Modify options(옵션 수정) 버튼 클릭 후 환경변수 선택)
- ```FINDEX_API_KEY=발급받은_API_KEY값```
3. 저장 후 애플리케이션 실행
4. 콘솔에 발급받은_API_KEY값 출력되는지 확인
