### PR TITLE
feat: 전역 예외 처리 인프라 구축 및 IndexInfo 연관관계 개선

### DIFF
--- a/src/main/java/com/codeit/findex/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/findex/common/error/GlobalExceptionHandler.java
@@ -1,35 +1,30 @@
 package com.codeit.findex.common.error;
 
+import com.codeit.findex.common.error.exception.BaseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
-import java.util.NoSuchElementException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleBadRequest(IllegalArgumentException e) {
-        return ResponseEntity.badRequest().body(
-                new ErrorResponse(LocalDateTime.now(), 400, "잘못된 요청입니다.", e.getMessage())
-        );
-    }
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+        HttpStatus httpStatus = e.getBaseErrorCode().getHttpStatus();
 
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ErrorResponse> handleNoSuchElement(NoSuchElementException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                new ErrorResponse(LocalDateTime.now(), 404, "조회할 지수 정보를 찾을 수 없습니다.", e.getMessage())
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                httpStatus.value(),
+                e.getBaseErrorCode().getMessage(),
+                e.getDetail()
         );
-    }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleServerError(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
-                new ErrorResponse(LocalDateTime.now(), 500, "서버 오류", e.getMessage())
-        );
+        return ResponseEntity
+                .status(httpStatus)
+                .body(errorResponse);
     }
 }
 

--- a/src/main/java/com/codeit/findex/common/error/errorcode/AutoSyncErrorCode.java
+++ b/src/main/java/com/codeit/findex/common/error/errorcode/AutoSyncErrorCode.java
@@ -1,0 +1,20 @@
+package com.codeit.findex.common.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AutoSyncErrorCode implements BaseErrorCode {
+
+    // 400
+    AUTO_SYNC_INVALID_SETTING(HttpStatus.BAD_REQUEST, "유효하지 않은 설정 값입니다."),
+    AUTO_SYNC_INVALID_FILTER(HttpStatus.BAD_REQUEST, "유효하지 않은 필터 값입니다."),
+
+    // 404
+    AUTO_SYNC_NOT_FOUND(HttpStatus.NOT_FOUND, "자동 연동 설정을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/codeit/findex/common/error/errorcode/BaseErrorCode.java
+++ b/src/main/java/com/codeit/findex/common/error/errorcode/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.codeit.findex.common.error.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/codeit/findex/common/error/errorcode/IndexDataErrorCode.java
+++ b/src/main/java/com/codeit/findex/common/error/errorcode/IndexDataErrorCode.java
@@ -1,0 +1,23 @@
+package com.codeit.findex.common.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum IndexDataErrorCode implements BaseErrorCode {
+
+    // 400
+    INDEX_DATA_DUPLICATED(HttpStatus.BAD_REQUEST, "지수 데이터가 중복입니다."),
+    INDEX_DATA_INVALID_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 데이터 값입니다."),
+    INDEX_DATA_INVALID_FILTER(HttpStatus.BAD_REQUEST, "유효하지 않은 필터 값입니다."),
+    INDEX_DATA_INVALID_PERIOD(HttpStatus.BAD_REQUEST, "유효하지 않은 기간 유형입니다."),
+
+    // 404
+    INDEX_DATA_NOT_FOUND(HttpStatus.NOT_FOUND, "지수 데이터를 찾을 수 없습니다."),
+    INDEX_DATA_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "참조하는 지수 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/codeit/findex/common/error/errorcode/IndexInfoErrorCode.java
+++ b/src/main/java/com/codeit/findex/common/error/errorcode/IndexInfoErrorCode.java
@@ -1,0 +1,22 @@
+package com.codeit.findex.common.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum IndexInfoErrorCode implements BaseErrorCode {
+
+    // 400
+    INDEX_INFO_DUPLICATED(HttpStatus.BAD_REQUEST, "지수 정보가 중복입니다."),
+    INDEX_INFO_REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "필수 필드가 누락되었습니다."),
+    INDEX_INFO_INVALID_FIELD(HttpStatus.BAD_REQUEST, "유효하지 않은 필드 값입니다."),
+    INDEX_INFO_INVALID_FILTER(HttpStatus.BAD_REQUEST, "유효하지 않은 필터 값입니다."),
+
+    // 404
+    INDEX_INFO_NOTFOUND(HttpStatus.NOT_FOUND, "지수 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/codeit/findex/common/error/errorcode/SyncJobErrorCode.java
+++ b/src/main/java/com/codeit/findex/common/error/errorcode/SyncJobErrorCode.java
@@ -1,0 +1,21 @@
+package com.codeit.findex.common.error.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SyncJobErrorCode implements BaseErrorCode {
+
+    // 400
+    ASYNC_JOB_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    ASYNC_JOB_INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "유효하지 않은 날짜 범위입니다."),
+    ASYNC_JOB_INVALID_FILTER(HttpStatus.BAD_REQUEST, "유효하지 않은 필터 값입니다."),
+
+    // 404
+    ASYNC_JOB_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "지수 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/codeit/findex/common/error/exception/AutoSyncException.java
+++ b/src/main/java/com/codeit/findex/common/error/exception/AutoSyncException.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.common.error.exception;
+
+import com.codeit.findex.common.error.errorcode.AutoSyncErrorCode;
+
+public class AutoSyncException extends BaseException {
+
+    public AutoSyncException(AutoSyncErrorCode autoSyncErrorCode) {
+        super(autoSyncErrorCode);
+    }
+
+    public AutoSyncException(AutoSyncErrorCode autoSyncErrorCode, String detail) {
+        super(autoSyncErrorCode, detail);
+    }
+}

--- a/src/main/java/com/codeit/findex/common/error/exception/BaseException.java
+++ b/src/main/java/com/codeit/findex/common/error/exception/BaseException.java
@@ -1,0 +1,20 @@
+package com.codeit.findex.common.error.exception;
+
+import com.codeit.findex.common.error.errorcode.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final BaseErrorCode baseErrorCode;
+    private String detail;
+
+    public BaseException(BaseErrorCode baseErrorCode) {
+        this.baseErrorCode = baseErrorCode;
+    }
+
+    public BaseException(BaseErrorCode baseErrorCode, String detail) {
+        this.baseErrorCode = baseErrorCode;
+        this.detail = detail;
+    }
+}

--- a/src/main/java/com/codeit/findex/common/error/exception/IndexDataException.java
+++ b/src/main/java/com/codeit/findex/common/error/exception/IndexDataException.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.common.error.exception;
+
+import com.codeit.findex.common.error.errorcode.IndexDataErrorCode;
+
+public class IndexDataException extends BaseException {
+
+    public IndexDataException(IndexDataErrorCode indexDataErrorCode) {
+        super(indexDataErrorCode);
+    }
+
+    public IndexDataException(IndexDataErrorCode indexDataErrorCode, String detail) {
+        super(indexDataErrorCode, detail);
+    }
+}

--- a/src/main/java/com/codeit/findex/common/error/exception/IndexInfoException.java
+++ b/src/main/java/com/codeit/findex/common/error/exception/IndexInfoException.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.common.error.exception;
+
+import com.codeit.findex.common.error.errorcode.IndexInfoErrorCode;
+
+public class IndexInfoException extends BaseException {
+
+    public IndexInfoException(IndexInfoErrorCode indexInfoErrorCode) {
+        super(indexInfoErrorCode);
+    }
+
+    public IndexInfoException(IndexInfoErrorCode indexInfoErrorCode, String detail) {
+        super(indexInfoErrorCode, detail);
+    }
+}

--- a/src/main/java/com/codeit/findex/common/error/exception/SyncJobException.java
+++ b/src/main/java/com/codeit/findex/common/error/exception/SyncJobException.java
@@ -1,0 +1,14 @@
+package com.codeit.findex.common.error.exception;
+
+import com.codeit.findex.common.error.errorcode.SyncJobErrorCode;
+
+public class SyncJobException extends BaseException {
+
+    public SyncJobException(SyncJobErrorCode syncJobErrorCode) {
+        super(syncJobErrorCode);
+    }
+
+    public SyncJobException(SyncJobErrorCode syncJobErrorCode, String detail) {
+        super(syncJobErrorCode, detail);
+    }
+}

--- a/src/main/java/com/codeit/findex/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/codeit/findex/indexinfo/entity/IndexInfo.java
@@ -2,19 +2,20 @@ package com.codeit.findex.indexinfo.entity;
 
 import com.codeit.findex.common.entity.BaseEntity;
 import com.codeit.findex.common.enums.SourceType;
+import com.codeit.findex.indexdata.entity.IndexData;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "index_info")
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class IndexInfo extends BaseEntity {
 
@@ -36,6 +37,19 @@ public class IndexInfo extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean favorite = false;
+
+    @OneToMany(mappedBy = "indexInfo", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<IndexData> indexDataList = new ArrayList<>();
+
+    public IndexInfo(String indexClassification, String indexName, Integer employedItemsCount, LocalDate basePointInTime, BigDecimal baseIndex, SourceType sourceType, Boolean favorite) {
+        this.indexClassification = indexClassification;
+        this.indexName = indexName;
+        this.employedItemsCount = employedItemsCount;
+        this.basePointInTime = basePointInTime;
+        this.baseIndex = baseIndex;
+        this.sourceType = sourceType;
+        this.favorite = favorite;
+    }
 
     public void changeEmployedItemsCount(Integer employedItemsCount) {
         this.employedItemsCount = employedItemsCount;


### PR DESCRIPTION
## 작업 내용
- 도메인별 `ErrorCode` 및 `Exception` 정의 추가
- `BaseErrorCode`, `BaseException` 기반 전역 예외 처리 인프라 구축
- `GlobalExceptionHandler`를 커스텀 예외 처리 구조로 리팩토링
- `IndexInfo` 엔티티에 `IndexData` 연관관계 및 cascade 삭제 처리 추가

## 주요 변경 사항
1. **예외 처리 인프라 추가**
   - `BaseErrorCode`, `BaseException` 정의
   - 도메인별 에러 코드(`IndexInfoErrorCode`, `IndexDataErrorCode`, `SyncJobErrorCode`, `AutoSyncErrorCode`) 추가
   - 도메인별 커스텀 예외(`IndexInfoException`, `IndexDataException`, `SyncJobException`, `AutoSyncException`) 정의

2. **전역 예외 처리 리팩토링**
   - `GlobalExceptionHandler`가 `BaseException`을 기반으로 모든 예외 처리

3. **서비스 계층 리팩토링**
   - 비즈니스 로직에서 도메인별 커스텀 예외를 사용하도록 변경

4. **엔티티 연관관계 개선**
   - `IndexInfo` -> `IndexData` 간 `cascade` 삭제 처리 및 생성자 추가

## 추가/변경된 파일
- `BaseErrorCode.java`, `BaseException.java`
- `IndexInfoErrorCode.java`, `IndexInfoException.java`
- `IndexDataErrorCode.java`, `IndexDataException.java`
- `SyncJobErrorCode.java`, `SyncJobException.java`
- `AutoSyncErrorCode.java`, `AutoSyncException.java`
- `GlobalExceptionHandler.java`
- `IndexInfo.java`
- `IndexInfoService.java`