### PR TITLE
chore: Railway 환경변수 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,9 @@ spring:
   application:
     name: Findex
   datasource:
-    url: jdbc:postgresql://localhost:5432/
-    username:
-    password:
+    url: ${RAILWAY_DB_URL}
+    username: ${RAILWAY_DB_USERNAME}
+    password: ${RAILWAY_DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
   servlet:
     multipart:


### PR DESCRIPTION
## 변경 내용
- `application.yml`에서 로컬 DB 설정 제거
- Railway에서 제공하는 환경변수(`DATABASE_URL`, `POSTGRES_USER`, `POSTGRES_PASSWORD`)를 사용하도록 수정

## 목적
- Railway 배포 환경에서 DB 및 API 연동 가능하도록 설정