### PR TITLE
feat: IndexInfo 삭제 로직 개선 및 커서 조회 기준 수정

### DIFF
--- a/src/main/java/com/codeit/findex/autosync/repository/AutoSyncConfigQueryRepositoryImpl.java
+++ b/src/main/java/com/codeit/findex/autosync/repository/AutoSyncConfigQueryRepositoryImpl.java
@@ -29,15 +29,15 @@ public class AutoSyncConfigQueryRepositoryImpl implements AutoSyncConfigQueryRep
         }
         if (idAfter != null) {
             if (sortDirection.isAscending()) {
-                where.and(config.id.gt(idAfter));
+                where.and(config.indexInfo.id.gt(idAfter));
             } else {
-                where.and(config.id.lt(idAfter));
+                where.and(config.indexInfo.id.lt(idAfter));
             }
         }
 
         return queryFactory.selectFrom(config)
                 .where(where)
-                .orderBy(sortDirection.isAscending() ? config.id.asc() : config.id.desc())
+                .orderBy(sortDirection.isAscending() ? config.indexInfo.id.asc() : config.indexInfo.id.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/com/codeit/findex/autosync/repository/AutoSyncConfigRepository.java
+++ b/src/main/java/com/codeit/findex/autosync/repository/AutoSyncConfigRepository.java
@@ -1,7 +1,11 @@
 package com.codeit.findex.autosync.repository;
 
 import com.codeit.findex.autosync.entity.AutoSyncConfig;
+import com.codeit.findex.indexinfo.entity.IndexInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +15,8 @@ public interface AutoSyncConfigRepository extends JpaRepository<AutoSyncConfig, 
     Optional<AutoSyncConfig> findByIndexInfoId(Long indexInfoId);
 
     List<AutoSyncConfig> findByEnabledTrue();
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from AutoSyncConfig a where a.indexInfo.id = :indexInfoId")
+    void deleteByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
 }

--- a/src/main/java/com/codeit/findex/indexdata/repository/IndexDataRepository.java
+++ b/src/main/java/com/codeit/findex/indexdata/repository/IndexDataRepository.java
@@ -3,6 +3,9 @@ package com.codeit.findex.indexdata.repository;
 import com.codeit.findex.indexdata.entity.IndexData;
 import com.codeit.findex.indexinfo.entity.IndexInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,5 +22,9 @@ public interface IndexDataRepository
   Optional<IndexData> findTop1ByIndexInfo_IdAndBaseDateLessThanEqualOrderByBaseDateDesc(
       Long indexInfoId, LocalDate baseDate);
 
-    Optional<IndexData> findByIndexInfoAndBaseDate(IndexInfo indexInfo, LocalDate basDt);
+  Optional<IndexData> findByIndexInfoAndBaseDate(IndexInfo indexInfo, LocalDate basDt);
+
+  @Modifying(clearAutomatically = true)
+  @Query("delete from IndexData d where d.indexInfo.id = :indexInfoId")
+  void deleteByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
 }

--- a/src/main/java/com/codeit/findex/indexinfo/entity/IndexInfo.java
+++ b/src/main/java/com/codeit/findex/indexinfo/entity/IndexInfo.java
@@ -2,20 +2,16 @@ package com.codeit.findex.indexinfo.entity;
 
 import com.codeit.findex.common.entity.BaseEntity;
 import com.codeit.findex.common.enums.SourceType;
-import com.codeit.findex.indexdata.entity.IndexData;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 @Entity
 @Table(name = "index_info")
 @Getter @Setter
-@AllArgsConstructor
 @NoArgsConstructor/*(access = AccessLevel.PROTECTED)*/
 public class IndexInfo extends BaseEntity {
 
@@ -37,9 +33,6 @@ public class IndexInfo extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean favorite = false;
-
-    @OneToMany(mappedBy = "indexInfo", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<IndexData> indexDataList = new ArrayList<>();
 
     public IndexInfo(String indexClassification, String indexName, Integer employedItemsCount, LocalDate basePointInTime, BigDecimal baseIndex, SourceType sourceType, Boolean favorite) {
         this.indexClassification = indexClassification;

--- a/src/main/java/com/codeit/findex/indexinfo/service/IndexInfoService.java
+++ b/src/main/java/com/codeit/findex/indexinfo/service/IndexInfoService.java
@@ -5,6 +5,7 @@ import com.codeit.findex.autosync.repository.AutoSyncConfigRepository;
 import com.codeit.findex.common.dto.PageResponse;
 import com.codeit.findex.common.enums.SourceType;
 import com.codeit.findex.common.error.exception.IndexInfoException;
+import com.codeit.findex.indexdata.repository.IndexDataRepository;
 import com.codeit.findex.indexinfo.dto.IndexInfoCreateRequest;
 import com.codeit.findex.indexinfo.dto.IndexInfoDto;
 import com.codeit.findex.indexinfo.dto.IndexInfoSummaryDto;
@@ -13,7 +14,9 @@ import com.codeit.findex.common.enums.SortDirection;
 import com.codeit.findex.indexinfo.entity.IndexInfo;
 import com.codeit.findex.indexinfo.mapper.IndexInfoMapper;
 import com.codeit.findex.indexinfo.repository.IndexInfoRepository;
+import com.codeit.findex.syncjob.repository.SyncJobRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,8 @@ import static com.codeit.findex.common.error.errorcode.IndexInfoErrorCode.*;
 public class IndexInfoService {
 
     private final IndexInfoRepository indexInfoRepository;
+    private final IndexDataRepository indexDataRepository;
+    private final SyncJobRepository syncJobRepository;
 
     private final IndexInfoMapper indexInfoMapper;
 
@@ -133,7 +138,7 @@ public class IndexInfoService {
     }
 
     public List<IndexInfoSummaryDto> findSummaryList() {
-        return indexInfoRepository.findAll()
+        return indexInfoRepository.findAll(Sort.by(Sort.Direction.ASC, "id"))
                 .stream()
                 .map(indexInfoMapper::toSummaryDto)
                 .toList();
@@ -163,11 +168,12 @@ public class IndexInfoService {
     }
 
     public void delete(Long id) {
-        // IndexInfo -> IndexData CascadeType 설정
-        // IndexInfo.java 참고
-        indexInfoRepository.findById(id)
+        IndexInfo indexInfo = indexInfoRepository.findById(id)
                 .orElseThrow(() -> new IndexInfoException(INDEX_INFO_NOTFOUND));
 
-        indexInfoRepository.deleteById(id);
+        syncJobRepository.deleteByIndexInfoId(indexInfo.getId());
+        autoSyncConfigRepository.deleteByIndexInfoId(indexInfo.getId());
+        indexDataRepository.deleteByIndexInfoId(indexInfo.getId());
+        indexInfoRepository.deleteById(indexInfo.getId());
     }
 }

--- a/src/main/java/com/codeit/findex/syncjob/repository/SyncJobRepository.java
+++ b/src/main/java/com/codeit/findex/syncjob/repository/SyncJobRepository.java
@@ -3,6 +3,9 @@ package com.codeit.findex.syncjob.repository;
 import com.codeit.findex.indexinfo.entity.IndexInfo;
 import com.codeit.findex.syncjob.entity.SyncJob;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -12,4 +15,8 @@ public interface SyncJobRepository extends JpaRepository<SyncJob, Long>, SyncJob
     Optional<SyncJob> findByIndexInfoAndJobType(IndexInfo indexInfo, String jobType);
 
     Optional<SyncJob> findByIndexInfoAndJobTypeAndTargetDate(IndexInfo indexInfo, String jobType, LocalDate targetDate);
+
+    @Modifying
+    @Query("delete from SyncJob sj where sj.indexInfo.id = :indexInfoId")
+    void deleteByIndexInfoId(@Param("indexInfoId") Long indexInfoId);
 }


### PR DESCRIPTION
## 변경사항
### IndexInfo 삭제 로직 개선
- IndexInfo 삭제 시 연관된 IndexData, SyncJob, AutoSyncConfig 데이터를 bulk delete로 처리
- FK 제약 조건 위반 문제 해결 및 대량 데이터 삭제 시 성능 최적화
### 조회 로직 보강
- IndexInfoService: 요약 조회 시 정렬 기준(id ASC) 추가 → 일관된 데이터 반환 보장
- AutoSyncConfigQuery: 커서 기반 조회 시 정렬 기준을 indexInfo.id로 변경

## 변경 파일
### 수정
- IndexInfoService.java → 삭제 로직 개선, 정렬 기준 추가
- AutoSyncConfigQueryRepositoryImpl.java → 커서 조회 시 정렬 기준 변경
### 삭제
- IndexInfo.java → 불필요해진 indexDataList 필드 제거
### 추가
- SyncJobRepository.java, AutoSyncConfigRepository.java, IndexDataRepository.java → bulk delete 메서드 추가