### PR TITLE
fix: 지수 데이터 연동 시 서버 오류 발생 문제 해결

### DIFF
--- a/src/main/java/com/codeit/findex/data/DataSyncRepository.java
+++ b/src/main/java/com/codeit/findex/data/DataSyncRepository.java
@@ -11,6 +11,7 @@ import com.codeit.findex.syncjob.repository.SyncJobRepository;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -214,8 +215,8 @@ public class DataSyncRepository {
     @Transactional
     public Set<SyncJob> storeIndexInfoToDb(List<Item> items, String ip) {
         Set<SyncJob> syncJobsList = new HashSet<>();
-        List<IndexInfo> indexInfoBatch = new ArrayList<>();
-        List<SyncJob> syncJobBatch = new ArrayList<>();
+        Set<IndexInfo> indexInfoBatch = new HashSet<>();
+        Set<SyncJob> syncJobBatch = new HashSet<>();
 
         for (Item item : items) {
             IndexInfo indexInfo = toIndexInfo(item);
@@ -250,10 +251,9 @@ public class DataSyncRepository {
 
     @Transactional
     public Set<SyncJob> storeIndexDataToDb(List<Item> items, String ip) {
-        Set<SyncJob> syncJobsList = new HashSet<>();
-        List<IndexInfo> indexInfoBatch = new ArrayList<>();
-        List<IndexData> indexDataBatch = new ArrayList<>();
-        List<SyncJob> syncJobBatch = new ArrayList<>();
+        Set<IndexInfo> indexInfoBatch = new HashSet<>();
+        Set<IndexData> indexDataBatch = new HashSet<>();
+        Set<SyncJob> syncJobBatch = new HashSet<>();
 
         for (Item item : items) {
             IndexInfo indexInfo = toIndexInfo(item);
@@ -275,20 +275,50 @@ public class DataSyncRepository {
                 indexInfoBatch.add(indexInfo);
             }
 
-            IndexData indexData = toIndexData(item, indexInfo);
-            indexDataBatch.add(indexData);
+            IndexData indexData = indexDataRepository.findByIndexInfoAndBaseDate(
+                            existedIndexInfo != null ? existedIndexInfo : indexInfo, item.getBasDt())
+                    .orElse(null);
 
-            SyncJob syncJob = toSyncJob(item, indexInfo, "INDEX_DATA");
-            syncJob.setWorker(ip);
-            syncJobBatch.add(syncJob);
+            if (indexData == null) {
+                IndexData newIndexData = toIndexData(item, existedIndexInfo);
+                indexDataBatch.add(newIndexData);
+            } else {
+                indexData.setBaseDate(item.getBasDt());
+                indexData.setMarketPrice(item.getMkp());
+                indexData.setClosingPrice(item.getClpr());
+                indexData.setHighPrice(item.getHipr());
+                indexData.setLowPrice(item.getLopr());
+                indexData.setVersus(item.getVs());
+                indexData.setFluctuationRate(item.getFltRt());
+                indexData.setTradingQuantity(item.getTrqu());
+                indexData.setTradingPrice(item.getTrPrc());
+                indexData.setMarketTotalAmount(item.getLstgMrktTotAmt());
+                indexData.setSourceType(SourceType.OPEN_API);
+                indexDataBatch.add(indexData);
+            }
+
+            SyncJob existingSyncJobOpt = syncJobRepository.findByIndexInfoAndJobTypeAndTargetDate(
+                    indexInfo, "INDEX_DATA", item.getBasDt()
+            ).orElse(null);
+
+            if (existingSyncJobOpt == null) {
+                SyncJob syncJob = toSyncJob(item, indexInfo, "INDEX_DATA");
+                syncJob.setWorker(ip);
+                syncJobBatch.add(syncJob);
+            } else {
+                existingSyncJobOpt.setTargetDate(item.getBasDt());
+                existingSyncJobOpt.setJobType("INDEX_DATA");
+                existingSyncJobOpt.setWorker(ip);
+                existingSyncJobOpt.setResult("SUCCESS");
+            }
+
         }
 
         indexInfoRepository.saveAll(indexInfoBatch);
         indexDataRepository.saveAll(indexDataBatch);
         syncJobRepository.saveAll(syncJobBatch);
 
-        syncJobsList.addAll(syncJobBatch);
-        return syncJobsList;
+        return syncJobBatch;
     }
 
     private boolean entityEquals(IndexInfo a, IndexInfo b) {

--- a/src/main/java/com/codeit/findex/data/scheduler/IndexApiScheduler.java
+++ b/src/main/java/com/codeit/findex/data/scheduler/IndexApiScheduler.java
@@ -13,6 +13,7 @@ public class IndexApiScheduler {
     private final AutoIndexDataSyncService autoIndexSyncService;
 
     @Scheduled(cron = "0 0 0 * * *")
+//    @Scheduled(initialDelay = 5000)
     public void task() throws Exception {
         System.out.println("오전 9시 30분 지수 데이터 연동:" + LocalDateTime.now());
         autoIndexSyncService.fetchAndProcessAll();

--- a/src/main/java/com/codeit/findex/syncjob/entity/SyncJob.java
+++ b/src/main/java/com/codeit/findex/syncjob/entity/SyncJob.java
@@ -47,11 +47,16 @@ public class SyncJob extends BaseEntity {
     public boolean equals(Object object) {
         if (object == null || getClass() != object.getClass()) return false;
         SyncJob syncJob = (SyncJob) object;
-        return Objects.equals(indexInfo, syncJob.indexInfo) && Objects.equals(jobType, syncJob.jobType) && Objects.equals(targetDate, syncJob.targetDate);
+
+        Long thisIndexInfoId = this.indexInfo != null ? this.indexInfo.getId() : null;
+        Long otherIndexInfoId = syncJob.indexInfo != null ? syncJob.indexInfo.getId() : null;
+
+        return Objects.equals(thisIndexInfoId, otherIndexInfoId) && Objects.equals(jobType, syncJob.jobType) && Objects.equals(targetDate, syncJob.targetDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(indexInfo, jobType, targetDate);
+        Long indexInfoId = indexInfo != null ? indexInfo.getId() : null;
+        return Objects.hash(indexInfoId, jobType, targetDate);
     }
 }

--- a/src/main/java/com/codeit/findex/syncjob/service/SyncJobService.java
+++ b/src/main/java/com/codeit/findex/syncjob/service/SyncJobService.java
@@ -73,7 +73,7 @@ public class SyncJobService {
                 })
                 .flatMap(Collection::stream)
                 .toList();
-    }
+}
 
     public CursorPageResponse<SyncJobDto> getSyncJobs(
             String          jobType,


### PR DESCRIPTION
## 변경 내용

- SyncJob 엔티티 내 equals(), hashcode() 추가
- DataSyncRepository.java의 storeIndexDataToDb 및 storeIndexInfoToDb 메서드에서 List 대신 Set 사용